### PR TITLE
chore: update adguard upstream dns and filter list

### DIFF
--- a/services/adguard/config/AdGuardHome.yaml
+++ b/services/adguard/config/AdGuardHome.yaml
@@ -23,8 +23,8 @@ dns:
   ratelimit_whitelist: []
   refuse_any: true
   upstream_dns:
-    - 1.1.1.1
-    - 8.8.4.4
+    - https://cloudflare-dns.com/dns-query
+    - https://dns.google/dns-query
     - '[/fritz.box/]192.168.178.1'
   upstream_dns_file: ""
   bootstrap_dns:


### PR DESCRIPTION
Disable "ppfeufer | adguard-filter-list" because it is to restrictive.