### PR TITLE
feat(frp): add proxy protocol

### DIFF
--- a/services/traefik/config/traefik.toml
+++ b/services/traefik/config/traefik.toml
@@ -22,6 +22,9 @@ readTimeout = "600s"
 idleTimeout = "600s"
 writeTimeout = "600s"
 
+[entryPoints.websecure.proxyProtocol]
+trustedIPs = "172.0.0.0/8"
+
 [certificatesResolvers]
 [certificatesResolvers.myresolver.acme]
 email = "matthias@emdemail.de"


### PR DESCRIPTION
This is done so that frp exposes user's real IP in HTTP header `X-Real-IP`, which can then be read by services like crowdsec.